### PR TITLE
refs #user_1 show subscription block for user 1

### DIFF
--- a/src/Plugin/Block/NewsletterSubscribe.php
+++ b/src/Plugin/Block/NewsletterSubscribe.php
@@ -86,7 +86,7 @@ class NewsletterSubscribe extends BlockBase implements ContainerFactoryPluginInt
       return AccessResult::forbidden();
     }
     // Bail if authenticated!
-    if ($account->isAuthenticated()) {
+    if ($account->isAuthenticated() && $account->id() != '1') {
       // For anonymous, the block is forbidden.
       return AccessResult::forbidden();
     }


### PR DESCRIPTION
Added check on user 1 on isAuthenticated so we can still see the newsletter blocks for root user.