### PR TITLE
Added new block 'block_civicrm_newsletter_authenticated_subscribe' and functionality to services + minor change

### DIFF
--- a/src/Form/NewsletterAuthenticatedSubscribe.php
+++ b/src/Form/NewsletterAuthenticatedSubscribe.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\civicrm_newsletter\Form;
+
+use Drupal\civicrm_newsletter\Utility\NewsletterInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class NewsletterSubscribe.
+ */
+class NewsletterAuthenticatedSubscribe extends FormBase {
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The Newsletter service.
+   *
+   * @var \Drupal\civicrm_newsletter\Utility\NewsLetterInterface
+   */
+  protected $newsletter;
+
+  /**
+   * The Newsletter service.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $account;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger'),
+      $container->get('civicrm_newsletter.list'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   * @param \Drupal\civicrm_newsletter\Utility\NewsLetterInterface $newsletter
+   *   The Newsletter service.
+   */
+  public function __construct(MessengerInterface $messenger, NewsLetterInterface $newsletter, AccountProxyInterface $account) {
+    $this->messenger = $messenger;
+    $this->newsletter = $newsletter;
+    $this->account = $account;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'civicrm_newsletter_form_subscribe_name_email';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $default_values = [
+      'first_name' => '',
+      'last_name'  => '',
+      'email'      => '',
+    ];
+
+    $result = $this->newsletter->getContactDetails();
+    if (isset($result['values'])) {
+      // If 1 contact is returned and its array key is 0.
+      if (count($result['values']) === 1 && isset($result['values'][0])) {
+        foreach ($default_values as $key => $value) {
+          if (isset($result['values'][0][$key])) {
+            $default_values[$key] = $result['values'][0][$key];
+          }
+        }
+      }
+    }
+
+    // Form components.
+    // Only show first_name and last_name if both are filled in on the contact.
+    if ($default_values['first_name'] !== '' && $default_values['last_name'] !== '') {
+      // The fields should be shown, but also disabled.
+      $form['first_name'] = [
+        '#type'          => 'textfield',
+        '#required'      => TRUE,
+        '#disabled'      => TRUE,
+        '#attributes'    => ['placeholder' => $this->t('First name')],
+        '#default_value' => $default_values['first_name']
+      ];
+
+      $form['last_name'] = [
+        '#type'          => 'textfield',
+        '#required'      => TRUE,
+        '#disabled'      => TRUE,
+        '#attributes'    => ['placeholder' => $this->t('Last name')],
+        '#default_value' => $default_values['last_name']
+      ];
+    }
+
+    $form['email'] = [
+      '#type'          => 'email',
+      '#required'      => TRUE,
+      '#disabled'      => TRUE,
+      '#attributes'    => ['placeholder' => $this->t('Email')],
+      '#description'   => $this->t('Please enter email address, read and accept the terms of use of the site.'),
+      '#default_value' => $default_values['email']
+    ];
+
+    $form['accept'] = [
+      '#type'  => 'checkbox',
+      '#title' => $this->t('I accept the terms of use of the site'),
+    ];
+
+    // Add a submit button that handles the submission of the form.
+    $form['actions']['submit'] = [
+      '#type'  => 'submit',
+      '#value' => $this->t('Subscribe'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    $accept = $form_state->getValue('accept');
+    if (empty($accept)) {
+      // Set an error for the form element with a key of "accept".
+      $form_state->setErrorByName('accept', $this->t('You must accept the terms of use to continue'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Groups.
+    $group = $this->config('civicrm_newsletter.settings')->get('default');
+    // Create the subscription for the existing user.
+    $this->newsletter->subscribeContact($group);
+    // Display the results.
+    $this->messenger->addMessage($this->t('The subscription has been submitted.'));
+  }
+
+}

--- a/src/Form/NewsletterAuthenticatedSubscribe.php
+++ b/src/Form/NewsletterAuthenticatedSubscribe.php
@@ -53,6 +53,8 @@ class NewsletterAuthenticatedSubscribe extends FormBase {
    *   The messenger service.
    * @param \Drupal\civicrm_newsletter\Utility\NewsLetterInterface $newsletter
    *   The Newsletter service.
+   * @param \Drupal\Core\Session\AccountProxyInterface $account
+   *   The account interface.
    */
   public function __construct(MessengerInterface $messenger, NewsLetterInterface $newsletter, AccountProxyInterface $account) {
     $this->messenger = $messenger;
@@ -98,7 +100,7 @@ class NewsletterAuthenticatedSubscribe extends FormBase {
         '#required'      => TRUE,
         '#disabled'      => TRUE,
         '#attributes'    => ['placeholder' => $this->t('First name')],
-        '#default_value' => $default_values['first_name']
+        '#default_value' => $default_values['first_name'],
       ];
 
       $form['last_name'] = [
@@ -106,7 +108,7 @@ class NewsletterAuthenticatedSubscribe extends FormBase {
         '#required'      => TRUE,
         '#disabled'      => TRUE,
         '#attributes'    => ['placeholder' => $this->t('Last name')],
-        '#default_value' => $default_values['last_name']
+        '#default_value' => $default_values['last_name'],
       ];
     }
 
@@ -116,7 +118,7 @@ class NewsletterAuthenticatedSubscribe extends FormBase {
       '#disabled'      => TRUE,
       '#attributes'    => ['placeholder' => $this->t('Email')],
       '#description'   => $this->t('Please enter email address, read and accept the terms of use of the site.'),
-      '#default_value' => $default_values['email']
+      '#default_value' => $default_values['email'],
     ];
 
     $form['accept'] = [

--- a/src/Form/NewsletterSubscribeName.php
+++ b/src/Form/NewsletterSubscribeName.php
@@ -89,7 +89,7 @@ class NewsletterSubscribeName extends FormBase {
     // Add a submit button that handles the submission of the form.
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Submit'),
+      '#value' => $this->t('Subscribe'),
     ];
     return $form;
   }

--- a/src/Plugin/Block/NewsletterAuthenticatedSubscribe.php
+++ b/src/Plugin/Block/NewsletterAuthenticatedSubscribe.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Drupal\civicrm_newsletter\Plugin\Block;
+
+use Drupal\civicrm_newsletter\Utility\NewsLetter;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'CiviCRM Newsletter' Block for authenticated users.
+ *
+ * @Block(
+ *   id = "block_civicrm_newsletter_authenticated_subscribe",
+ *   admin_label = @Translation("CiviCRM Newsletter: Subscribe (for authenticated users)"),
+ *   category = @Translation("CiviCRM"),
+ * )
+ */
+class NewsletterAuthenticatedSubscribe extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The Config.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $config;
+
+  /**
+   * The Newsletter service.
+   *
+   * @var \Drupal\civicrm_newsletter\Utility\NewsLetterInterface
+   */
+  protected $newsletter;
+
+  /**
+   * The current logged in user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $account;
+
+  /**
+   * Constructs a FormBuilder object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The Form Builder.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory services.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, FormBuilderInterface $form_builder, ConfigFactoryInterface $config_factory, NewsLetter $newsletter, AccountProxyInterface $account) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->formBuilder = $form_builder;
+    $this->config = $config_factory;
+    $this->newsletter = $newsletter;
+    $this->account = $account;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('form_builder'),
+      $container->get('config.factory'),
+      $container->get('civicrm_newsletter.list'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'manage_subscription_url' => '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form['manage_subscription_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Manage subscription location'),
+      '#description' => $this->t('The URL where users can manage their subscriptions (example: /user/profile).
+      This is displayed to users when they have already subscribed.
+      '),
+      '#default_value' => $this->configuration['manage_subscription_url'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $this->configuration['manage_subscription_url'] = $values['manage_subscription_url'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $allowed = $this->config->get('civicrm_newsletter.settings')->get('default');
+    // Return form.
+    if ($this->newsletter->isContactSubscribed($allowed)) {
+      $markup = '<p>' . t('You are already subscribed to our newsletter.') . '</p>';
+      if ($this->configuration['manage_subscription_url'] !== '') {
+        $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+        $url = '/' . $language . $this->configuration['manage_subscription_url'];
+        $markup .= t('<p>You can manage your subscriptions <a href="@link">here</a>.</p>', ['@link' => $url]);
+      }
+
+      return [
+        '#type' => 'markup',
+        '#markup' => $markup,
+      ];
+    } else {
+      return $this->formBuilder->getForm('Drupal\civicrm_newsletter\Form\NewsletterAuthenticatedSubscribe');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    // Bail if no groups are defined!
+    $allowed = $this->config->get('civicrm_newsletter.settings')->get('default');
+    if (!isset($allowed) || empty(array_filter($allowed))) {
+      return AccessResult::forbidden();
+    }
+    // Bail if anonymous!
+    if ($account->isAnonymous()) {
+      // For anonymous, the block is forbidden.
+      return AccessResult::forbidden();
+    }
+    else {
+      // For authenticated, the block is allowed.
+      return AccessResult::allowed();
+    }
+  }
+
+}

--- a/src/Plugin/Block/NewsletterSubscribeName.php
+++ b/src/Plugin/Block/NewsletterSubscribeName.php
@@ -6,8 +6,10 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -36,6 +38,20 @@ class NewsletterSubscribeName extends BlockBase implements ContainerFactoryPlugi
   protected $config;
 
   /**
+   * The current logged in user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $account;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs a FormBuilder object.
    *
    * @param array $configuration
@@ -48,11 +64,17 @@ class NewsletterSubscribeName extends BlockBase implements ContainerFactoryPlugi
    *   The Form Builder.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory services.
+   * @param \Drupal\Core\Session\AccountProxyInterface $account
+   *   The account interface.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, FormBuilderInterface $form_builder, ConfigFactoryInterface $config_factory) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, FormBuilderInterface $form_builder, ConfigFactoryInterface $config_factory, AccountProxyInterface $account, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->formBuilder = $form_builder;
     $this->config = $config_factory;
+    $this->account = $account;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -64,7 +86,9 @@ class NewsletterSubscribeName extends BlockBase implements ContainerFactoryPlugi
       $plugin_id,
       $plugin_definition,
       $container->get('form_builder'),
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('current_user'),
+      $container->get('messenger')
     );
   }
 
@@ -72,6 +96,15 @@ class NewsletterSubscribeName extends BlockBase implements ContainerFactoryPlugi
    * {@inheritdoc}
    */
   public function build() {
+    if ($this->account->id() == 1) {
+      $this->messenger->addMessage(
+        $this->t(
+          "Displaying newsletter subscribe block on this page as a result of the current user's unique permissions."
+        ),
+        $this->messenger::TYPE_STATUS
+      );
+    }
+
     // Return form.
     return $this->formBuilder->getForm('Drupal\civicrm_newsletter\Form\NewsletterSubscribeName');
   }

--- a/src/Utility/NewsLetter.php
+++ b/src/Utility/NewsLetter.php
@@ -174,19 +174,24 @@ class NewsLetter implements NewsletterInterface {
    * {@inheritdoc}
    */
   public function isContactSubscribed($groups, $contact_id = 'user_contact_id') {
-    $result = [];
+    $subscribed = TRUE;
 
     foreach ($groups as $key => $value) {
       if ($value != 0) {
-        // Add contact to group.
         $result = $this->api('Contact', 'get', [
           'sequential' => 1,
           'group' => $key,
           'id' => $contact_id,
         ]);
+
+        // If we found a group and the contact was not in it, he is not subscribed to all available groups.
+        if (empty($result['values'])) {
+          $subscribed = FALSE;
+          break;
+        }
       }
     }
-    return !empty($result['values']);
+    return $subscribed;
   }
 
   /**

--- a/src/Utility/NewsLetter.php
+++ b/src/Utility/NewsLetter.php
@@ -184,7 +184,8 @@ class NewsLetter implements NewsletterInterface {
           'id' => $contact_id,
         ]);
 
-        // If we found a group and the contact was not in it, he is not subscribed to all available groups.
+        // If we found a group and the contact was not in it,
+        // he is not subscribed to all available groups.
         if (empty($result['values'])) {
           $subscribed = FALSE;
           break;

--- a/src/Utility/NewsLetter.php
+++ b/src/Utility/NewsLetter.php
@@ -170,4 +170,52 @@ class NewsLetter implements NewsletterInterface {
     return $result;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function isContactSubscribed($groups, $contact_id = 'user_contact_id') {
+    $result = [];
+
+    foreach ($groups as $key => $value) {
+      if ($value != 0) {
+        // Add contact to group.
+        $result = $this->api('Contact', 'get', [
+          'sequential' => 1,
+          'group' => $key,
+          'id' => $contact_id,
+        ]);
+      }
+    }
+    return !empty($result['values']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function subscribeContact($groups, $contact_id = 'user_contact_id') {
+    $result = [];
+
+    foreach ($groups as $key => $value) {
+      if ($value != 0) {
+        // Add contact to group.
+        $result[] = $this->api('GroupContact', 'Create', [
+          'group_id' => $key,
+          'contact_id' => $contact_id,
+          'status' => 'Added',
+        ]);
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContactDetails($contact_id = 'user_contact_id') {
+    return $this->api('Contact', 'get', [
+      'sequential' => 1,
+      'id' => $contact_id,
+    ]);
+  }
+
 }

--- a/src/Utility/NewsletterInterface.php
+++ b/src/Utility/NewsletterInterface.php
@@ -34,7 +34,7 @@ interface NewsletterInterface {
    * @return array
    *   An array with result(s).
    */
-  public function createSubscription($params, $groups);
+  public function createSubscription(array $params, $groups);
 
   /**
    * Updates mailing subscription(s) via the CiviCRM api.

--- a/src/Utility/NewsletterInterface.php
+++ b/src/Utility/NewsletterInterface.php
@@ -47,4 +47,44 @@ interface NewsletterInterface {
    */
   public function updateSubscription($groups);
 
+  /**
+   * Checks if the given contact is subscribed to the supplied group(s).
+   *
+   * @param mixed $groups
+   *   The newsletter group(s).
+   * @param string $contact_id
+   *   The supplied contact_id.
+   *   Defaults to 'user_contact_id'.
+   *
+   * @return bool
+   *   Returns if the contact is subscribed to the supplied group(s) or not.
+   */
+  public function isContactSubscribed($groups, $contact_id = 'user_contact_id');
+
+  /**
+   * Subscribes the supplied contact to the supplied group(s).
+   *
+   * @param mixed $groups
+   *   The newsletter group(s).
+   * @param string $contact_id
+   *   The supplied contact_id.
+   *   Defaults to 'user_contact_id'.
+   *
+   * @return mixed
+   *   An array with result(s).
+   */
+  public function subscribeContact($groups, $contact_id = 'user_contact_id');
+
+  /**
+   * Gets the contact information of the supplied contact.
+   *
+   * @param string $contact_id
+   *   The supplied contact_id.
+   *   Defaults to 'user_contact_id'.
+   *
+   * @return mixed
+   *   Returns the API result.
+   */
+  public function getContactDetails($contact_id = 'user_contact_id');
+
 }


### PR DESCRIPTION
# authenticated_subscription_block

Added new block 'block_civicrm_newsletter_authenticated_subscribe' which provides a block for authenticated users to subscribe to the configured groups. If the contacts first name and last name are available we show them together with the email, but all form fields are disabled as we add the existing contact to the group and not the field values.

When a user is subscribed to all the configured groups this will be indicated on the block with the following text:
> You are already subscribed to our newsletter.

The block comes with a configuration that allows u to provide an internal URL to the manage subscriptions block. When it is filled in the indication on the block will change to the following text:
> You are already subscribed to our newsletter.
> You can manage your subscriptions [here](example.com).

'here' links to the provided internal URL (Note that we prepend the current language to the URL when rendering the block. External links are not supported).

# newsletter_subscribe_name

Added a minor change that changed the text on the submit button from 'submit' to 'subscribe' so users can provide a more accurate translation.