### PR TITLE
refs #cache Fix issue with authenticated subscribe block incorrectly …

### DIFF
--- a/src/Plugin/Block/NewsletterAuthenticatedSubscribe.php
+++ b/src/Plugin/Block/NewsletterAuthenticatedSubscribe.php
@@ -183,4 +183,11 @@ class NewsletterAuthenticatedSubscribe extends BlockBase implements ContainerFac
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
+  }
+
 }


### PR DESCRIPTION
When a user is subscribed and visits the homepage his authenticated subscribe block is cached with the already subscribed content.

When the user unsubscribes through the manage form and goes back to the authenticated subscribe block he will still see that already subscribed content.

My solution is setting the cache max age to 0 for the authenticated block.